### PR TITLE
调整了Buffer的判断，添加了浏览器使用兼容以及浏览器的Uint8Array，将注释改用为JSDoc注释

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # JavaScript SM3
 
 ## 简介
-国密SM3密码杂凑算法的JavaScript实现。目前只能在服务器端环境Node.js使用。
+国密SM3密码杂凑算法的JavaScript实现。目前可在服务器端环境Node.js以及浏览器环境使用。
 
 ## 使用
 直接下载源代码将sm3.js拷贝到你的项目中，或者使用[npm](https://www.npmjs.org/)安装：

--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
 # JavaScript SM3
 
 ## 简介
-国密SM3密码杂凑算法的JavaScript实现。目前可在服务器端环境Node.js以及浏览器环境使用。
+
+国密 SM3 密码杂凑算法的 JavaScript 实现。目前可在服务器端环境 Node.js 以及浏览器环境使用。
 
 ## 使用
-直接下载源代码将sm3.js拷贝到你的项目中，或者使用[npm](https://www.npmjs.org/)安装：
+
+直接下载源代码将 sm3.js 拷贝到你的项目中，或者使用 [npm](https://www.npmjs.org/) 安装：
+
+### Node.js：
 
 ```sh
 npm install sm3
@@ -15,9 +19,18 @@ const sm3 = require('sm3');
 const hash = sm3('值');
 ```
 
+### 浏览器：
+
+```html
+<script type='application/javascript' src='sm3.js'></script>
+<script>console.log(sm3('值'));</script>
+```
+
 ## 要求
-没有依赖，但Node.js版本需>=6.0.0，或使用sm3-babel.js文件（Node.js版本>=1.0.0），
-也可自行使用[Babel](http://babeljs.io/)对sm3.js文件进行转化
+
+没有依赖，但 Node.js 版本需要>=6.0.0，或使用 sm3-babel.js 文件（Node.js 版本>=1.0.0），
+也可自行使用 [Babel](http://babeljs.io/) 对 sm3.js 文件进行转化
+
 ```sh
 babel sm3.js --out-file sm3-babel.js
 ```
@@ -29,7 +42,9 @@ const hash = sm3('值');
 ```
 
 ## 参考
-[SM3密码杂凑算法](http://www.sca.gov.cn/sca/xwdt/2010-12/17/1002389/files/302a3ada057c4a73830536d03e683110.pdf)
+
+[SM3 密码杂凑算法](http://www.sca.gov.cn/sca/xwdt/2010-12/17/1002389/files/302a3ada057c4a73830536d03e683110.pdf)
 
 ## License
+
 [MIT license](http://www.opensource.org/licenses/MIT).

--- a/sm3.js
+++ b/sm3.js
@@ -3,6 +3,7 @@
  * https://github.com/jiaxingzheng/JavaScript-SM3
  *
  * Copyright 2017, Zheng Jiaxing
+ * Edit 2021, Jo Young, Sonic853
  *
  * Licensed under the MIT license:
  * http://www.opensource.org/licenses/MIT
@@ -16,7 +17,7 @@
    * 左补0到指定长度
    * @param {string} str 
    * @param {number} totalLength 
-   * @returns 
+   * @returns {string}
    */
   function leftPad(str, totalLength) {
     const len = str.length;
@@ -26,7 +27,7 @@
   /**
    * 二进制转化为十六进制
    * @param {string} binary 
-   * @returns 
+   * @returns {string}
    */
   function binary2hex(binary) {
     const binaryLength = 8;
@@ -40,7 +41,7 @@
   /**
    * 十六进制转化为二进制
    * @param {string} hex 
-   * @returns 
+   * @returns {string}
    */
   function hex2binary(hex) {
     const hexLength = 2;
@@ -53,8 +54,8 @@
 
   /**
    * utf16码点值转化为utf8二进制
-   * @param {*} ch 
-   * @returns 
+   * @param {string} ch 
+   * @returns {string}
    */
   function utf16CodePoint2utf8Binary(ch) {
     const utf8Arr = [];
@@ -89,7 +90,7 @@
   /**
    * 普通字符串转化为二进制
    * @param {string} str 
-   * @returns 
+   * @returns {string}
    */
   function str2binary(str) {
     let binary = '';
@@ -101,9 +102,9 @@
 
   /**
    * 循环左移
-   * @param {*} str 
-   * @param {*} n 
-   * @returns 
+   * @param {string} str 
+   * @param {number} n 
+   * @returns {string}
    */
   function rol(str, n) {
     return str.substring(n % str.length) + str.substr(0, n % str.length);
@@ -111,10 +112,10 @@
 
   /**
    * 二进制运算
-   * @param {*} x 
-   * @param {*} y 
-   * @param {*} method 
-   * @returns 
+   * @param {string} x 
+   * @param {string} y 
+   * @param {Function} method 
+   * @returns {string}
    */
   function binaryCal(x, y, method) {
     const a = x || '';
@@ -132,9 +133,9 @@
 
   /**
    * 二进制异或运算
-   * @param {*} x 
-   * @param {*} y 
-   * @returns 
+   * @param {string} x 
+   * @param {string} y 
+   * @returns {string}
    */
   function xor(x, y) {
     return binaryCal(x, y, (a, b) => [(a === b ? '0' : '1')]);
@@ -142,9 +143,9 @@
 
   /**
    * 二进制与运算
-   * @param {*} x 
-   * @param {*} y 
-   * @returns 
+   * @param {string} x 
+   * @param {string} y 
+   * @returns {string}
    */
   function and(x, y) {
     return binaryCal(x, y, (a, b) => [(a === '1' && b === '1' ? '1' : '0')]);
@@ -152,9 +153,9 @@
 
   /**
    * 二进制或运算
-   * @param {*} x 
-   * @param {*} y 
-   * @returns 
+   * @param {string} x 
+   * @param {string} y 
+   * @returns {string}
    */
   function or(x, y) {
     return binaryCal(x, y, (a, b) => [(a === '1' || b === '1' ? '1' : '0')]);// a === '0' && b === '0' ? '0' : '1'
@@ -162,9 +163,9 @@
 
   /**
    * 二进制与运算
-   * @param {*} x 
-   * @param {*} y 
-   * @returns 
+   * @param {string} x 
+   * @param {string} y 
+   * @returns {string}
    */
   function add(x, y) {
     const result = binaryCal(x, y, (a, b, prevResult) => {
@@ -179,13 +180,18 @@
 
   /**
    * 二进制非运算
-   * @param {*} x 
-   * @returns 
+   * @param {string} x 
+   * @returns {string}
    */
   function not(x) {
     return binaryCal(x, undefined, a => [a === '1' ? '0' : '1']);
   }
 
+  /**
+   * 
+   * @param {Function} method 
+   * @returns 
+   */
   function calMulti(method) {
     return (...arr) => arr.reduce((prev, curr) => method(prev, curr));
   }
@@ -196,8 +202,8 @@
 
   /**
    * 压缩函数中的置换函数 P1(X) = X xor (X <<< 9) xor (X <<< 17)
-   * @param {*} X 
-   * @returns 
+   * @param {string} X 
+   * @returns {string}
    */
   function P0(X) {
     return calMulti(xor)(X, rol(X, 9), rol(X, 17));
@@ -205,8 +211,8 @@
 
   /**
    * 消息扩展中的置换函数 P1(X) = X xor (X <<< 15) xor (X <<< 23)
-   * @param {*} X 
-   * @returns 
+   * @param {string} X 
+   * @returns {string}
    */
   function P1(X) {
     return calMulti(xor)(X, rol(X, 15), rol(X, 23));
@@ -214,11 +220,11 @@
 
   /**
    * 布尔函数，随j的变化取不同的表达式
-   * @param {*} X 
-   * @param {*} Y 
-   * @param {*} Z 
-   * @param {*} j 
-   * @returns 
+   * @param {string} X 
+   * @param {string} Y 
+   * @param {string} Z 
+   * @param {number} j 
+   * @returns {string}
    */
   function FF(X, Y, Z, j) {
     return j >= 0 && j <= 15 ? calMulti(xor)(X, Y, Z) : calMulti(or)(and(X, Y), and(X, Z), and(Y, Z));
@@ -226,11 +232,11 @@
 
   /**
    * 布尔函数，随j的变化取不同的表达式
-   * @param {*} X 
-   * @param {*} Y 
-   * @param {*} Z 
-   * @param {*} j 
-   * @returns 
+   * @param {string} X 
+   * @param {string} Y 
+   * @param {string} Z 
+   * @param {number} j 
+   * @returns {string}
    */
   function GG(X, Y, Z, j) {
     return j >= 0 && j <= 15 ? calMulti(xor)(X, Y, Z) : or(and(X, Y), and(not(X), Z));
@@ -238,8 +244,8 @@
 
   /**
    * 常量，随j的变化取不同的值
-   * @param {*} j 
-   * @returns 
+   * @param {number} j 
+   * @returns {string}
    */
   function T(j) {
     return j >= 0 && j <= 15 ? hex2binary('79cc4519') : hex2binary('7a879d8a');
@@ -249,7 +255,7 @@
    * 压缩函数
    * @param {string} V 
    * @param {string} Bi 
-   * @returns 
+   * @returns {string}
    */
   function CF(V, Bi) {
     // 消息扩展
@@ -351,4 +357,4 @@
   }
   if (typeof module !== 'undefined' && typeof module.exports !== 'undefined') module.exports = sm3;
   else window.sm3 = sm3;
-})()
+})();

--- a/sm3.js
+++ b/sm3.js
@@ -317,7 +317,7 @@ function CF(V, Bi) {
 }
 
 /**
- * sm3 hash算法 http://www.oscca.gov.cn/News/201012/News_1199.htm
+ * sm3 hash算法 https://sca.gov.cn/sca/xwdt/2010-12/17/content_1002389.shtml
  * @param {string|Buffer} content 输入string或Buffer
  * @returns {string} 返回经过sm3算法的hash
  */

--- a/sm3.js
+++ b/sm3.js
@@ -324,12 +324,12 @@
 
   /**
    * sm3 hash算法 https://sca.gov.cn/sca/xwdt/2010-12/17/content_1002389.shtml
-   * @param {string|Buffer} content 输入string或Buffer
+   * @param {string|Buffer|Uint8Array} content 输入string、Buffer或Uint8Array
    * @returns {string} 返回经过sm3算法的hash
    */
   function sm3(content) {
     let binary = '';
-    if (typeof Buffer !== 'undefined' && Buffer.isBuffer(content)) {
+    if ((typeof Buffer !== 'undefined' && Buffer.isBuffer(content))||(typeof Uint8Array !== 'undefined' && content instanceof Object.getPrototypeOf(Uint8Array))) {
       for (a of content) {
         binary += a.toString(2).padStart(8, '0');
       }

--- a/sm3.js
+++ b/sm3.js
@@ -11,343 +11,344 @@
  * http://www.oscca.gov.cn/UpFile/20101222141857786.pdf
  */
 
-
-/**
- * 左补0到指定长度
- * @param {string} str 
- * @param {number} totalLength 
- * @returns 
- */
-function leftPad(str, totalLength) {
-  const len = str.length;
-  return Array(totalLength > len ? ((totalLength - len) + 1) : 0).join(0) + str;
-}
-
-/**
- * 二进制转化为十六进制
- * @param {string} binary 
- * @returns 
- */
-function binary2hex(binary) {
-  const binaryLength = 8;
-  let hex = '';
-  for (let i = 0; i < binary.length / binaryLength; i += 1) {
-    hex += leftPad(parseInt(binary.substr(i * binaryLength, binaryLength), 2).toString(16), 2);
-  }
-  return hex;
-}
-
-/**
- * 十六进制转化为二进制
- * @param {string} hex 
- * @returns 
- */
-function hex2binary(hex) {
-  const hexLength = 2;
-  let binary = '';
-  for (let i = 0; i < hex.length / hexLength; i += 1) {
-    binary += leftPad(parseInt(hex.substr(i * hexLength, hexLength), 16).toString(2), 8);
-  }
-  return binary;
-}
-
-/**
- * utf16码点值转化为utf8二进制
- * @param {*} ch 
- * @returns 
- */
-function utf16CodePoint2utf8Binary(ch) {
-  const utf8Arr = [];
-  const codePoint = ch.codePointAt(0);
-
-  if (codePoint >= 0x00 && codePoint <= 0x7f) {
-    utf8Arr.push(codePoint);
-  } else if (codePoint >= 0x80 && codePoint <= 0x7ff) {
-    utf8Arr.push((192 | (31 & (codePoint >> 6))));
-    utf8Arr.push((128 | (63 & codePoint)))
-  } else if ((codePoint >= 0x800 && codePoint <= 0xd7ff)
-    || (codePoint >= 0xe000 && codePoint <= 0xffff)) {
-    utf8Arr.push((224 | (15 & (codePoint >> 12))));
-    utf8Arr.push((128 | (63 & (codePoint >> 6))));
-    utf8Arr.push((128 | (63 & codePoint)))
-  } else if (codePoint >= 0x10000 && codePoint <= 0x10ffff) {
-    utf8Arr.push((240 | (7 & (codePoint >> 18))));
-    utf8Arr.push((128 | (63 & (codePoint >> 12))));
-    utf8Arr.push((128 | (63 & (codePoint >> 6))));
-    utf8Arr.push((128 | (63 & codePoint)))
+(() => {
+  /**
+   * 左补0到指定长度
+   * @param {string} str 
+   * @param {number} totalLength 
+   * @returns 
+   */
+  function leftPad(str, totalLength) {
+    const len = str.length;
+    return Array(totalLength > len ? ((totalLength - len) + 1) : 0).join(0) + str;
   }
 
-  let binary = '';
-  for (let utf8Code of utf8Arr) {
-    const b = utf8Code.toString(2);
-    binary += leftPad(b, Math.ceil(b.length / 8) * 8);
-  }
-
-  return binary;
-}
-
-/**
- * 普通字符串转化为二进制
- * @param {string} str 
- * @returns 
- */
-function str2binary(str) {
-  let binary = '';
-  for (const ch of str) {
-    binary += utf16CodePoint2utf8Binary(ch);
-  }
-  return binary;
-}
-
-/**
- * 循环左移
- * @param {*} str 
- * @param {*} n 
- * @returns 
- */
-function rol(str, n) {
-  return str.substring(n % str.length) + str.substr(0, n % str.length);
-}
-
-/**
- * 二进制运算
- * @param {*} x 
- * @param {*} y 
- * @param {*} method 
- * @returns 
- */
-function binaryCal(x, y, method) {
-  const a = x || '';
-  const b = y || '';
-  const result = [];
-  let prevResult;
-  // for (let i = 0; i < a.length; i += 1) { // 小端
-  for (let i = a.length - 1; i >= 0; i -= 1) { // 大端
-    prevResult = method(a[i], b[i], prevResult);
-    result[i] = prevResult[0];
-  }
-  // console.log(`x     :${x}\ny     :${y}\nresult:${result.join('')}\n`);
-  return result.join('');
-}
-
-/**
- * 二进制异或运算
- * @param {*} x 
- * @param {*} y 
- * @returns 
- */
-function xor(x, y) {
-  return binaryCal(x, y, (a, b) => [(a === b ? '0' : '1')]);
-}
-
-/**
- * 二进制与运算
- * @param {*} x 
- * @param {*} y 
- * @returns 
- */
-function and(x, y) {
-  return binaryCal(x, y, (a, b) => [(a === '1' && b === '1' ? '1' : '0')]);
-}
-
-/**
- * 二进制或运算
- * @param {*} x 
- * @param {*} y 
- * @returns 
- */
-function or(x, y) {
-  return binaryCal(x, y, (a, b) => [(a === '1' || b === '1' ? '1' : '0')]);// a === '0' && b === '0' ? '0' : '1'
-}
-
-/**
- * 二进制与运算
- * @param {*} x 
- * @param {*} y 
- * @returns 
- */
-function add(x, y) {
-  const result = binaryCal(x, y, (a, b, prevResult) => {
-    const carry = prevResult ? prevResult[1] : '0' || '0';
-    if (a !== b) return [carry === '0' ? '1' : '0', carry];// a,b不等时,carry不变，结果与carry相反
-    // a,b相等时，结果等于原carry，新carry等于a
-    return [carry, a];
-  });
-  // console.log('x: ' + x + '\ny: ' + y + '\n=  ' + result + '\n');
-  return result;
-}
-
-/**
- * 二进制非运算
- * @param {*} x 
- * @returns 
- */
-function not(x) {
-  return binaryCal(x, undefined, a => [a === '1' ? '0' : '1']);
-}
-
-function calMulti(method) {
-  return (...arr) => arr.reduce((prev, curr) => method(prev, curr));
-}
-
-// function xorMulti(...arr) {
-//   return arr.reduce((prev, curr) => xor(prev, curr));
-// }
-
-/**
- * 压缩函数中的置换函数 P1(X) = X xor (X <<< 9) xor (X <<< 17)
- * @param {*} X 
- * @returns 
- */
-function P0(X) {
-  return calMulti(xor)(X, rol(X, 9), rol(X, 17));
-}
-
-/**
- * 消息扩展中的置换函数 P1(X) = X xor (X <<< 15) xor (X <<< 23)
- * @param {*} X 
- * @returns 
- */
-function P1(X) {
-  return calMulti(xor)(X, rol(X, 15), rol(X, 23));
-}
-
-/**
- * 布尔函数，随j的变化取不同的表达式
- * @param {*} X 
- * @param {*} Y 
- * @param {*} Z 
- * @param {*} j 
- * @returns 
- */
-function FF(X, Y, Z, j) {
-  return j >= 0 && j <= 15 ? calMulti(xor)(X, Y, Z) : calMulti(or)(and(X, Y), and(X, Z), and(Y, Z));
-}
-
-/**
- * 布尔函数，随j的变化取不同的表达式
- * @param {*} X 
- * @param {*} Y 
- * @param {*} Z 
- * @param {*} j 
- * @returns 
- */
-function GG(X, Y, Z, j) {
-  return j >= 0 && j <= 15 ? calMulti(xor)(X, Y, Z) : or(and(X, Y), and(not(X), Z));
-}
-
-/**
- * 常量，随j的变化取不同的值
- * @param {*} j 
- * @returns 
- */
-function T(j) {
-  return j >= 0 && j <= 15 ? hex2binary('79cc4519') : hex2binary('7a879d8a');
-}
-
-/**
- * 压缩函数
- * @param {string} V 
- * @param {string} Bi 
- * @returns 
- */
-function CF(V, Bi) {
-  // 消息扩展
-  const wordLength = 32;
-  const W = [];
-  const M = [];// W'
-
-  // 将消息分组B划分为16个字W0， W1，…… ，W15 （字为长度为32的比特串）
-  for (let i = 0; i < 16; i += 1) {
-    W.push(Bi.substr(i * wordLength, wordLength));
-  }
-
-  // W[j] <- P1(W[j−16] xor W[j−9] xor (W[j−3] <<< 15)) xor (W[j−13] <<< 7) xor W[j−6]
-  for (let j = 16; j < 68; j += 1) {
-    W.push(calMulti(xor)(
-      P1(calMulti(xor)(W[j - 16], W[j - 9], rol(W[j - 3], 15))),
-      rol(W[j - 13], 7),
-      W[j - 6]
-    ));
-  }
-
-  // W′[j] = W[j] xor W[j+4]
-  for (let j = 0; j < 64; j += 1) {
-    M.push(xor(W[j], W[j + 4]));
-  }
-
-  // 压缩
-  const wordRegister = [];// 字寄存器
-  for (let j = 0; j < 8; j += 1) {
-    wordRegister.push(V.substr(j * wordLength, wordLength));
-  }
-
-  let A = wordRegister[0];
-  let B = wordRegister[1];
-  let C = wordRegister[2];
-  let D = wordRegister[3];
-  let E = wordRegister[4];
-  let F = wordRegister[5];
-  let G = wordRegister[6];
-  let H = wordRegister[7];
-
-  // 中间变量
-  let SS1;
-  let SS2;
-  let TT1;
-  let TT2;
-  for (let j = 0; j < 64; j += 1) {
-    SS1 = rol(calMulti(add)(rol(A, 12), E, rol(T(j), j)), 7);
-    SS2 = xor(SS1, rol(A, 12));
-
-    TT1 = calMulti(add)(FF(A, B, C, j), D, SS2, M[j]);
-    TT2 = calMulti(add)(GG(E, F, G, j), H, SS1, W[j]);
-
-    D = C;
-    C = rol(B, 9);
-    B = A;
-    A = TT1;
-    H = G;
-    G = rol(F, 19);
-    F = E;
-    E = P0(TT2);
-  }
-
-  return xor(Array(A, B, C, D, E, F, G, H).join(''), V);
-}
-
-/**
- * sm3 hash算法 https://sca.gov.cn/sca/xwdt/2010-12/17/content_1002389.shtml
- * @param {string|Buffer} content 输入string或Buffer
- * @returns {string} 返回经过sm3算法的hash
- */
-function sm3(content) {
-  let binary = '';
-  if (typeof Buffer !== 'undefined' && Buffer.isBuffer(content)) {
-    for (a of content) {
-      binary += a.toString(2).padStart(8, '0');
+  /**
+   * 二进制转化为十六进制
+   * @param {string} binary 
+   * @returns 
+   */
+  function binary2hex(binary) {
+    const binaryLength = 8;
+    let hex = '';
+    for (let i = 0; i < binary.length / binaryLength; i += 1) {
+      hex += leftPad(parseInt(binary.substr(i * binaryLength, binaryLength), 2).toString(16), 2);
     }
+    return hex;
   }
-  else {
-    binary = str2binary(content);
+
+  /**
+   * 十六进制转化为二进制
+   * @param {string} hex 
+   * @returns 
+   */
+  function hex2binary(hex) {
+    const hexLength = 2;
+    let binary = '';
+    for (let i = 0; i < hex.length / hexLength; i += 1) {
+      binary += leftPad(parseInt(hex.substr(i * hexLength, hexLength), 16).toString(2), 8);
+    }
+    return binary;
   }
-  // 填充
-  const len = binary.length;
-  // k是满足len + 1 + k = 448mod512的最小的非负整数
-  let k = len % 512;
-  // 如果 448 <= (512 % len) < 512，需要多补充 (len % 448) 比特'0'以满足总比特长度为512的倍数
-  k = k >= 448 ? 512 - (k % 448) - 1 : 448 - k - 1;
-  const m = `${binary}1${leftPad('', k)}${leftPad(len.toString(2), 64)}`.toString();// k个0
 
-  // 迭代压缩
-  const n = (len + k + 65) / 512;
+  /**
+   * utf16码点值转化为utf8二进制
+   * @param {*} ch 
+   * @returns 
+   */
+  function utf16CodePoint2utf8Binary(ch) {
+    const utf8Arr = [];
+    const codePoint = ch.codePointAt(0);
 
-  let V = hex2binary('7380166f4914b2b9172442d7da8a0600a96f30bc163138aae38dee4db0fb0e4e');
-  for (let i = 0; i <= n - 1; i += 1) {
-    const B = m.substr(512 * i, 512);
-    V = CF(V, B);
+    if (codePoint >= 0x00 && codePoint <= 0x7f) {
+      utf8Arr.push(codePoint);
+    } else if (codePoint >= 0x80 && codePoint <= 0x7ff) {
+      utf8Arr.push((192 | (31 & (codePoint >> 6))));
+      utf8Arr.push((128 | (63 & codePoint)))
+    } else if ((codePoint >= 0x800 && codePoint <= 0xd7ff)
+      || (codePoint >= 0xe000 && codePoint <= 0xffff)) {
+      utf8Arr.push((224 | (15 & (codePoint >> 12))));
+      utf8Arr.push((128 | (63 & (codePoint >> 6))));
+      utf8Arr.push((128 | (63 & codePoint)))
+    } else if (codePoint >= 0x10000 && codePoint <= 0x10ffff) {
+      utf8Arr.push((240 | (7 & (codePoint >> 18))));
+      utf8Arr.push((128 | (63 & (codePoint >> 12))));
+      utf8Arr.push((128 | (63 & (codePoint >> 6))));
+      utf8Arr.push((128 | (63 & codePoint)))
+    }
+
+    let binary = '';
+    for (let utf8Code of utf8Arr) {
+      const b = utf8Code.toString(2);
+      binary += leftPad(b, Math.ceil(b.length / 8) * 8);
+    }
+
+    return binary;
   }
-  return binary2hex(V);
-}
 
-module.exports = sm3
+  /**
+   * 普通字符串转化为二进制
+   * @param {string} str 
+   * @returns 
+   */
+  function str2binary(str) {
+    let binary = '';
+    for (const ch of str) {
+      binary += utf16CodePoint2utf8Binary(ch);
+    }
+    return binary;
+  }
+
+  /**
+   * 循环左移
+   * @param {*} str 
+   * @param {*} n 
+   * @returns 
+   */
+  function rol(str, n) {
+    return str.substring(n % str.length) + str.substr(0, n % str.length);
+  }
+
+  /**
+   * 二进制运算
+   * @param {*} x 
+   * @param {*} y 
+   * @param {*} method 
+   * @returns 
+   */
+  function binaryCal(x, y, method) {
+    const a = x || '';
+    const b = y || '';
+    const result = [];
+    let prevResult;
+    // for (let i = 0; i < a.length; i += 1) { // 小端
+    for (let i = a.length - 1; i >= 0; i -= 1) { // 大端
+      prevResult = method(a[i], b[i], prevResult);
+      result[i] = prevResult[0];
+    }
+    // console.log(`x     :${x}\ny     :${y}\nresult:${result.join('')}\n`);
+    return result.join('');
+  }
+
+  /**
+   * 二进制异或运算
+   * @param {*} x 
+   * @param {*} y 
+   * @returns 
+   */
+  function xor(x, y) {
+    return binaryCal(x, y, (a, b) => [(a === b ? '0' : '1')]);
+  }
+
+  /**
+   * 二进制与运算
+   * @param {*} x 
+   * @param {*} y 
+   * @returns 
+   */
+  function and(x, y) {
+    return binaryCal(x, y, (a, b) => [(a === '1' && b === '1' ? '1' : '0')]);
+  }
+
+  /**
+   * 二进制或运算
+   * @param {*} x 
+   * @param {*} y 
+   * @returns 
+   */
+  function or(x, y) {
+    return binaryCal(x, y, (a, b) => [(a === '1' || b === '1' ? '1' : '0')]);// a === '0' && b === '0' ? '0' : '1'
+  }
+
+  /**
+   * 二进制与运算
+   * @param {*} x 
+   * @param {*} y 
+   * @returns 
+   */
+  function add(x, y) {
+    const result = binaryCal(x, y, (a, b, prevResult) => {
+      const carry = prevResult ? prevResult[1] : '0' || '0';
+      if (a !== b) return [carry === '0' ? '1' : '0', carry];// a,b不等时,carry不变，结果与carry相反
+      // a,b相等时，结果等于原carry，新carry等于a
+      return [carry, a];
+    });
+    // console.log('x: ' + x + '\ny: ' + y + '\n=  ' + result + '\n');
+    return result;
+  }
+
+  /**
+   * 二进制非运算
+   * @param {*} x 
+   * @returns 
+   */
+  function not(x) {
+    return binaryCal(x, undefined, a => [a === '1' ? '0' : '1']);
+  }
+
+  function calMulti(method) {
+    return (...arr) => arr.reduce((prev, curr) => method(prev, curr));
+  }
+
+  // function xorMulti(...arr) {
+  //   return arr.reduce((prev, curr) => xor(prev, curr));
+  // }
+
+  /**
+   * 压缩函数中的置换函数 P1(X) = X xor (X <<< 9) xor (X <<< 17)
+   * @param {*} X 
+   * @returns 
+   */
+  function P0(X) {
+    return calMulti(xor)(X, rol(X, 9), rol(X, 17));
+  }
+
+  /**
+   * 消息扩展中的置换函数 P1(X) = X xor (X <<< 15) xor (X <<< 23)
+   * @param {*} X 
+   * @returns 
+   */
+  function P1(X) {
+    return calMulti(xor)(X, rol(X, 15), rol(X, 23));
+  }
+
+  /**
+   * 布尔函数，随j的变化取不同的表达式
+   * @param {*} X 
+   * @param {*} Y 
+   * @param {*} Z 
+   * @param {*} j 
+   * @returns 
+   */
+  function FF(X, Y, Z, j) {
+    return j >= 0 && j <= 15 ? calMulti(xor)(X, Y, Z) : calMulti(or)(and(X, Y), and(X, Z), and(Y, Z));
+  }
+
+  /**
+   * 布尔函数，随j的变化取不同的表达式
+   * @param {*} X 
+   * @param {*} Y 
+   * @param {*} Z 
+   * @param {*} j 
+   * @returns 
+   */
+  function GG(X, Y, Z, j) {
+    return j >= 0 && j <= 15 ? calMulti(xor)(X, Y, Z) : or(and(X, Y), and(not(X), Z));
+  }
+
+  /**
+   * 常量，随j的变化取不同的值
+   * @param {*} j 
+   * @returns 
+   */
+  function T(j) {
+    return j >= 0 && j <= 15 ? hex2binary('79cc4519') : hex2binary('7a879d8a');
+  }
+
+  /**
+   * 压缩函数
+   * @param {string} V 
+   * @param {string} Bi 
+   * @returns 
+   */
+  function CF(V, Bi) {
+    // 消息扩展
+    const wordLength = 32;
+    const W = [];
+    const M = [];// W'
+
+    // 将消息分组B划分为16个字W0， W1，…… ，W15 （字为长度为32的比特串）
+    for (let i = 0; i < 16; i += 1) {
+      W.push(Bi.substr(i * wordLength, wordLength));
+    }
+
+    // W[j] <- P1(W[j−16] xor W[j−9] xor (W[j−3] <<< 15)) xor (W[j−13] <<< 7) xor W[j−6]
+    for (let j = 16; j < 68; j += 1) {
+      W.push(calMulti(xor)(
+        P1(calMulti(xor)(W[j - 16], W[j - 9], rol(W[j - 3], 15))),
+        rol(W[j - 13], 7),
+        W[j - 6]
+      ));
+    }
+
+    // W′[j] = W[j] xor W[j+4]
+    for (let j = 0; j < 64; j += 1) {
+      M.push(xor(W[j], W[j + 4]));
+    }
+
+    // 压缩
+    const wordRegister = [];// 字寄存器
+    for (let j = 0; j < 8; j += 1) {
+      wordRegister.push(V.substr(j * wordLength, wordLength));
+    }
+
+    let A = wordRegister[0];
+    let B = wordRegister[1];
+    let C = wordRegister[2];
+    let D = wordRegister[3];
+    let E = wordRegister[4];
+    let F = wordRegister[5];
+    let G = wordRegister[6];
+    let H = wordRegister[7];
+
+    // 中间变量
+    let SS1;
+    let SS2;
+    let TT1;
+    let TT2;
+    for (let j = 0; j < 64; j += 1) {
+      SS1 = rol(calMulti(add)(rol(A, 12), E, rol(T(j), j)), 7);
+      SS2 = xor(SS1, rol(A, 12));
+
+      TT1 = calMulti(add)(FF(A, B, C, j), D, SS2, M[j]);
+      TT2 = calMulti(add)(GG(E, F, G, j), H, SS1, W[j]);
+
+      D = C;
+      C = rol(B, 9);
+      B = A;
+      A = TT1;
+      H = G;
+      G = rol(F, 19);
+      F = E;
+      E = P0(TT2);
+    }
+
+    return xor(Array(A, B, C, D, E, F, G, H).join(''), V);
+  }
+
+  /**
+   * sm3 hash算法 https://sca.gov.cn/sca/xwdt/2010-12/17/content_1002389.shtml
+   * @param {string|Buffer} content 输入string或Buffer
+   * @returns {string} 返回经过sm3算法的hash
+   */
+  function sm3(content) {
+    let binary = '';
+    if (typeof Buffer !== 'undefined' && Buffer.isBuffer(content)) {
+      for (a of content) {
+        binary += a.toString(2).padStart(8, '0');
+      }
+    }
+    else {
+      binary = str2binary(content);
+    }
+    // 填充
+    const len = binary.length;
+    // k是满足len + 1 + k = 448mod512的最小的非负整数
+    let k = len % 512;
+    // 如果 448 <= (512 % len) < 512，需要多补充 (len % 448) 比特'0'以满足总比特长度为512的倍数
+    k = k >= 448 ? 512 - (k % 448) - 1 : 448 - k - 1;
+    const m = `${binary}1${leftPad('', k)}${leftPad(len.toString(2), 64)}`.toString();// k个0
+
+    // 迭代压缩
+    const n = (len + k + 65) / 512;
+
+    let V = hex2binary('7380166f4914b2b9172442d7da8a0600a96f30bc163138aae38dee4db0fb0e4e');
+    for (let i = 0; i <= n - 1; i += 1) {
+      const B = m.substr(512 * i, 512);
+      V = CF(V, B);
+    }
+    return binary2hex(V);
+  }
+  if (typeof module !== 'undefined' && typeof module.exports !== 'undefined') module.exports = sm3;
+  else window.sm3 = sm3;
+})()

--- a/sm3.js
+++ b/sm3.js
@@ -12,13 +12,22 @@
  */
 
 
-// 左补0到指定长度
+/**
+ * 左补0到指定长度
+ * @param {string} str 
+ * @param {number} totalLength 
+ * @returns 
+ */
 function leftPad(str, totalLength) {
   const len = str.length;
   return Array(totalLength > len ? ((totalLength - len) + 1) : 0).join(0) + str;
 }
 
-// 二进制转化为十六进制
+/**
+ * 二进制转化为十六进制
+ * @param {string} binary 
+ * @returns 
+ */
 function binary2hex(binary) {
   const binaryLength = 8;
   let hex = '';
@@ -28,7 +37,11 @@ function binary2hex(binary) {
   return hex;
 }
 
-// 十六进制转化为二进制
+/**
+ * 十六进制转化为二进制
+ * @param {string} hex 
+ * @returns 
+ */
 function hex2binary(hex) {
   const hexLength = 2;
   let binary = '';
@@ -38,7 +51,11 @@ function hex2binary(hex) {
   return binary;
 }
 
-// utf16码点值转化为utf8二进制
+/**
+ * utf16码点值转化为utf8二进制
+ * @param {*} ch 
+ * @returns 
+ */
 function utf16CodePoint2utf8Binary(ch) {
   const utf8Arr = [];
   const codePoint = ch.codePointAt(0);
@@ -69,7 +86,11 @@ function utf16CodePoint2utf8Binary(ch) {
   return binary;
 }
 
-// 普通字符串转化为二进制
+/**
+ * 普通字符串转化为二进制
+ * @param {string} str 
+ * @returns 
+ */
 function str2binary(str) {
   let binary = '';
   for (const ch of str) {
@@ -78,12 +99,23 @@ function str2binary(str) {
   return binary;
 }
 
-// 循环左移
+/**
+ * 循环左移
+ * @param {*} str 
+ * @param {*} n 
+ * @returns 
+ */
 function rol(str, n) {
   return str.substring(n % str.length) + str.substr(0, n % str.length);
 }
 
-// 二进制运算
+/**
+ * 二进制运算
+ * @param {*} x 
+ * @param {*} y 
+ * @param {*} method 
+ * @returns 
+ */
 function binaryCal(x, y, method) {
   const a = x || '';
   const b = y || '';
@@ -98,22 +130,42 @@ function binaryCal(x, y, method) {
   return result.join('');
 }
 
-// 二进制异或运算
+/**
+ * 二进制异或运算
+ * @param {*} x 
+ * @param {*} y 
+ * @returns 
+ */
 function xor(x, y) {
   return binaryCal(x, y, (a, b) => [(a === b ? '0' : '1')]);
 }
 
-// 二进制与运算
+/**
+ * 二进制与运算
+ * @param {*} x 
+ * @param {*} y 
+ * @returns 
+ */
 function and(x, y) {
   return binaryCal(x, y, (a, b) => [(a === '1' && b === '1' ? '1' : '0')]);
 }
 
-// 二进制或运算
+/**
+ * 二进制或运算
+ * @param {*} x 
+ * @param {*} y 
+ * @returns 
+ */
 function or(x, y) {
   return binaryCal(x, y, (a, b) => [(a === '1' || b === '1' ? '1' : '0')]);// a === '0' && b === '0' ? '0' : '1'
 }
 
-// 二进制与运算
+/**
+ * 二进制与运算
+ * @param {*} x 
+ * @param {*} y 
+ * @returns 
+ */
 function add(x, y) {
   const result = binaryCal(x, y, (a, b, prevResult) => {
     const carry = prevResult ? prevResult[1] : '0' || '0';
@@ -125,7 +177,11 @@ function add(x, y) {
   return result;
 }
 
-// 二进制非运算
+/**
+ * 二进制非运算
+ * @param {*} x 
+ * @returns 
+ */
 function not(x) {
   return binaryCal(x, undefined, a => [a === '1' ? '0' : '1']);
 }
@@ -138,32 +194,63 @@ function calMulti(method) {
 //   return arr.reduce((prev, curr) => xor(prev, curr));
 // }
 
-// 压缩函数中的置换函数 P1(X) = X xor (X <<< 9) xor (X <<< 17)
+/**
+ * 压缩函数中的置换函数 P1(X) = X xor (X <<< 9) xor (X <<< 17)
+ * @param {*} X 
+ * @returns 
+ */
 function P0(X) {
   return calMulti(xor)(X, rol(X, 9), rol(X, 17));
 }
 
-// 消息扩展中的置换函数 P1(X) = X xor (X <<< 15) xor (X <<< 23)
+/**
+ * 消息扩展中的置换函数 P1(X) = X xor (X <<< 15) xor (X <<< 23)
+ * @param {*} X 
+ * @returns 
+ */
 function P1(X) {
   return calMulti(xor)(X, rol(X, 15), rol(X, 23));
 }
 
-// 布尔函数，随j的变化取不同的表达式
+/**
+ * 布尔函数，随j的变化取不同的表达式
+ * @param {*} X 
+ * @param {*} Y 
+ * @param {*} Z 
+ * @param {*} j 
+ * @returns 
+ */
 function FF(X, Y, Z, j) {
   return j >= 0 && j <= 15 ? calMulti(xor)(X, Y, Z) : calMulti(or)(and(X, Y), and(X, Z), and(Y, Z));
 }
 
-// 布尔函数，随j的变化取不同的表达式
+/**
+ * 布尔函数，随j的变化取不同的表达式
+ * @param {*} X 
+ * @param {*} Y 
+ * @param {*} Z 
+ * @param {*} j 
+ * @returns 
+ */
 function GG(X, Y, Z, j) {
   return j >= 0 && j <= 15 ? calMulti(xor)(X, Y, Z) : or(and(X, Y), and(not(X), Z));
 }
 
-// 常量，随j的变化取不同的值
+/**
+ * 常量，随j的变化取不同的值
+ * @param {*} j 
+ * @returns 
+ */
 function T(j) {
   return j >= 0 && j <= 15 ? hex2binary('79cc4519') : hex2binary('7a879d8a');
 }
 
-// 压缩函数
+/**
+ * 压缩函数
+ * @param {string} V 
+ * @param {string} Bi 
+ * @returns 
+ */
 function CF(V, Bi) {
   // 消息扩展
   const wordLength = 32;
@@ -229,22 +316,27 @@ function CF(V, Bi) {
   return xor(Array(A, B, C, D, E, F, G, H).join(''), V);
 }
 
-// sm3 hash算法 http://www.oscca.gov.cn/News/201012/News_1199.htm
+/**
+ * sm3 hash算法 http://www.oscca.gov.cn/News/201012/News_1199.htm
+ * @param {string|Buffer} content 输入string或Buffer
+ * @returns {string} 返回经过sm3算法的hash
+ */
 function sm3(content) {
-  let binary = ""
-  if (typeof content == 'string') {
-    binary = str2binary(content);
-  } else {
+  let binary = '';
+  if (typeof Buffer !== 'undefined' && Buffer.isBuffer(content)) {
     for (a of content) {
-      binary += a.toString(2).padStart(8, "0")
+      binary += a.toString(2).padStart(8, '0');
     }
+  }
+  else {
+    binary = str2binary(content);
   }
   // 填充
   const len = binary.length;
   // k是满足len + 1 + k = 448mod512的最小的非负整数
   let k = len % 512;
   // 如果 448 <= (512 % len) < 512，需要多补充 (len % 448) 比特'0'以满足总比特长度为512的倍数
-  k = k >= 448 ? 512 - (k % 448) - 1: 448 - k - 1;
+  k = k >= 448 ? 512 - (k % 448) - 1 : 448 - k - 1;
   const m = `${binary}1${leftPad('', k)}${leftPad(len.toString(2), 64)}`.toString();// k个0
 
   // 迭代压缩

--- a/test.html
+++ b/test.html
@@ -1,0 +1,37 @@
+<!DOCTYPE HTML>
+<html>
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+        content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0,minimal-ui:ios">
+    <title>JavaScript SM3</title>
+</head>
+
+<body>
+    <input type="text" name="text" id="inputText"><button id="SubmitText">生成</button><br>
+    <input type="file" id="inputFile" /><br>
+    SM3结果：<span id="SM3Text"></span>
+    <script type="application/javascript" src="sm3.js"></script>
+    <script>
+        let inputText = document.getElementById("inputText");
+        let SubmitText = document.getElementById("SubmitText");
+        let SM3Text = document.getElementById("SM3Text");
+        SubmitText.onclick = () => {
+            SM3Text.innerText = sm3(inputText.value);
+        }
+
+        let inputFile = document.getElementById("inputFile");
+        inputFile.onchange = () => {
+            let reader = new FileReader();
+            reader.onload = () => {
+                // let arrayBuffer = reader.result;
+                let array = new Uint8Array(reader.result);
+                SM3Text.innerText = sm3(array);
+            }
+            if(inputFile.files.length !== 0) reader.readAsArrayBuffer(inputFile.files[0]);
+        }
+    </script>
+</body>
+
+</html>


### PR DESCRIPTION
目前的判断为：如果Buffer为undefined或输入的内容类型不为Buffer，或Uint8Array为undefined或输入的内容类型不为Uint8Array，将默认以string类型处理，

同时增加了NodeJS和浏览器环境之间的判断，把所有函数包在匿名函数里运行，如果module和module.exports为undefined时，将当做浏览器环境处理。

将注释改用为JSDoc注释后，在VSCode上调用sm3时，就能出现以下注释：
![image](https://user-images.githubusercontent.com/8389962/112405550-74697a80-8d4d-11eb-9e9a-d0c7115ffe17.png)

目前在NodeJS和浏览器环境里均正常运行。